### PR TITLE
Applied OpenMP & Some Refactoring With FFT

### DIFF
--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -17,7 +17,7 @@ android {
         /* This externalNativeBuild block is different from the one which is on the outside of defaultConfig  */
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++14"
+                cppFlags "-std=c++14 -fopenmp"
                 arguments "-DANDROID_STL=c++_shared"
                 arguments "-DANDROID_SDK_ROOT=${android.getSdkDirectory().getAbsolutePath()}"
             }

--- a/euphony/src/androidTest/java/co/euphony/tx/CodeMakerTest.java
+++ b/euphony/src/androidTest/java/co/euphony/tx/CodeMakerTest.java
@@ -43,7 +43,7 @@ public class CodeMakerTest {
     int expectedStreamLength;
     int expectedBufferLength;
     public CodeMakerTest(String expectedGenCode, int expectedStreamLength, int expectedBufferLength) {
-        fft = new KissFFTWrapper(512);
+        fft = null;
         this.expectedGenCode = expectedGenCode;
         this.expectedStreamLength = expectedStreamLength;
         this.expectedBufferLength = expectedBufferLength;
@@ -78,6 +78,7 @@ public class CodeMakerTest {
         short[] stream = codeMaker.assembleData(expectedGenCode);
         assertEquals(expectedStreamLength, stream.length);
 
+        fft = new KissFFTWrapper(512);
         FloatBuffer[] buf = fft.makeSpectrum(stream);
         assertEquals(expectedBufferLength, buf.length);
         fft.finish();

--- a/euphony/src/androidTest/java/co/euphony/tx/TxUnitTest.java
+++ b/euphony/src/androidTest/java/co/euphony/tx/TxUnitTest.java
@@ -71,7 +71,7 @@ public class TxUnitTest {
 
     @Before
     public void setup() {
-        fft = new KissFFTWrapper(512);
+        fft = null;
     }
 
     @Test
@@ -84,6 +84,7 @@ public class TxUnitTest {
         streamLength = txManager.getOutStream().length;
         assertEquals(expectedStreamLength, streamLength);
 
+        fft = new KissFFTWrapper(512);
         FloatBuffer[] buf = fft.makeSpectrum(txManager.getOutStream());
         assertEquals(expectedBufferLength, buf.length);
         fft.finish();

--- a/euphony/src/main/cpp/CMakeLists.txt
+++ b/euphony/src/main/cpp/CMakeLists.txt
@@ -9,11 +9,15 @@ set(LEGACY_SRC
         arms/kiss_fftr.c
         native-legacy.cpp
         )
+
+find_library( log-lib log )
 add_library( native-legacy SHARED ${LEGACY_SRC} )
 target_compile_definitions(native-legacy PUBLIC FIXED_POINT=16)
 target_link_libraries(
         native-legacy
         ${log-lib}
+        -fopenmp
+        -static-openmp
 )
 
 # for euphony
@@ -42,11 +46,6 @@ include_directories( ${EUPHONY_HDR} ${SL_HEADERS} ${DEBUG_HELPER})
 # add_library ( <name> [STATIC|SHARED|MODULE] <src> <src> )
 add_library(euphony SHARED ${EUPHONY_SRC} ${DEBUG_HELPER_SRC})
 target_compile_definitions(euphony PUBLIC FIXED_POINT=16)
-find_library( # Sets the name of the path variable.
-        log-lib
-        # Specifies the name of the NDK library that
-        # you want CMake to locate.
-        log )
 
 find_package(
         oboe REQUIRED CONFIG

--- a/euphony/src/main/cpp/arms/kiss_fft.c
+++ b/euphony/src/main/cpp/arms/kiss_fft.c
@@ -271,8 +271,9 @@ void kf_work(
             f += fstride * in_stride;
         }
     }else{
+        int fstride_next = fstride * p;
         for(; Fout != Fout_end; Fout += m) {
-            kf_work(Fout, f, fstride * p, in_stride, factors, st);
+            kf_work(Fout, f, fstride_next, in_stride, factors, st);
             f += fstride * in_stride;
         }
     }
@@ -368,12 +369,10 @@ void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin, kiss_fft_cpx *fout
             return;
         }
 
-        __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","tmpbuf call on kfwork at stride");
         kf_work(tmpbuf, fin,1, in_stride, st->factors,st);
         memcpy(fout, tmpbuf, tmpBufMemorySize);
         free(tmpbuf);
     } else {
-        __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","kfwork call at stride");
         kf_work( fout, fin, 1, in_stride, st->factors,st );
     }
 }

--- a/euphony/src/main/cpp/arms/kiss_fft.c
+++ b/euphony/src/main/cpp/arms/kiss_fft.c
@@ -4,32 +4,17 @@
  fixed or floating point complex numbers.  It also delares the kf_ internal functions.
  */
 
-static kiss_fft_cpx *scratchbuf=NULL;
-static size_t nscratchbuf=0;
-static kiss_fft_cpx *tmpbuf=NULL;
-static size_t ntmpbuf=0;
-
-#define CHECKBUF(buf,nbuf,n) \
-    do { \
-        if ( nbuf < (size_t)(n) ) {\
-            free(buf); \
-            buf = (kiss_fft_cpx*)KISS_FFT_MALLOC(sizeof(kiss_fft_cpx)*(n)); \
-            nbuf = (size_t)(n); \
-        } \
-   }while(0)
-
-
-static void kf_bfly2(
+static
+void kf_bfly2(
         kiss_fft_cpx * Fout,
         const size_t fstride,
         const kiss_fft_cfg st,
         int m
         )
 {
-    kiss_fft_cpx * Fout2;
-    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx *tw1 = st->twiddles;
     kiss_fft_cpx t;
-    Fout2 = Fout + m;
+    kiss_fft_cpx *Fout2 = Fout + m;
     do{
         C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
 
@@ -42,7 +27,8 @@ static void kf_bfly2(
     }while (--m);
 }
 
-static void kf_bfly4(
+static
+void kf_bfly4(
         kiss_fft_cpx * Fout,
         const size_t fstride,
         const kiss_fft_cfg st,
@@ -89,7 +75,8 @@ static void kf_bfly4(
     }while(--k);
 }
 
-static void kf_bfly3(
+static
+void kf_bfly3(
          kiss_fft_cpx * Fout,
          const size_t fstride,
          const kiss_fft_cfg st,
@@ -133,7 +120,8 @@ static void kf_bfly3(
      }while(--k);
 }
 
-static void kf_bfly5(
+static
+void kf_bfly5(
         kiss_fft_cpx * Fout,
         const size_t fstride,
         const kiss_fft_cfg st,
@@ -195,7 +183,8 @@ static void kf_bfly5(
 }
 
 /* perform the butterfly for one stage of a mixed radix FFT */
-static void kf_bfly_generic(
+static
+void kf_bfly_generic(
         kiss_fft_cpx * Fout,
         const size_t fstride,
         const kiss_fft_cfg st,
@@ -208,12 +197,16 @@ static void kf_bfly_generic(
     kiss_fft_cpx t;
     int Norig = st->nfft;
 
-    CHECKBUF(scratchbuf,nscratchbuf,p);
+    kiss_fft_cpx *scratchbuf = (kiss_fft_cpx*) KISS_FFT_MALLOC(sizeof(kiss_fft_cpx) * p);
+    if(scratchbuf == NULL) {
+        __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_BFLY_GENERIC","scratch buffer is NULL.");
+        return;
+    }
 
     for ( u=0; u<m; ++u ) {
         k=u;
         for ( q1=0 ; q1<p ; ++q1 ) {
-            scratchbuf[q1] = Fout[ k  ];
+            scratchbuf[q1] = Fout[ k ];
             C_FIXDIV(scratchbuf[q1],p);
             k += m;
         }
@@ -231,24 +224,25 @@ static void kf_bfly_generic(
             k += m;
         }
     }
+
+    free(scratchbuf);
+    scratchbuf = NULL;
 }
 
 static
 void kf_work(
-        kiss_fft_cpx * Fout,
-        const kiss_fft_cpx * f,
+        kiss_fft_cpx *Fout,
+        const kiss_fft_cpx *f,
         const size_t fstride,
-        int in_stride,
+        const int in_stride,
         int * factors,
         const kiss_fft_cfg st
         )
 {
-	//__android_log_print(ANDROID_LOG_INFO,"----","1");
-    kiss_fft_cpx * Fout_beg=Fout;
     const int p=*factors++; /* the radix  */
     const int m=*factors++; /* stage's fft length/p */
-    const kiss_fft_cpx * Fout_end = Fout + p*m;
-   // __android_log_print(ANDROID_LOG_INFO,"----","2");
+    kiss_fft_cpx *Fout_beg=Fout;
+    const kiss_fft_cpx *Fout_end = Fout + p * m;
 #ifdef _OPENMP
     // use openmp extensions at the
     // top-level (not recursive)
@@ -271,25 +265,18 @@ void kf_work(
         return;
     }
 #endif
-    //__android_log_print(ANDROID_LOG_INFO,"----","3");
     if (m==1) {
-        do{
+        for(; Fout != Fout_end; Fout++) {
             *Fout = *f;
-            f += fstride*in_stride;
-        }while(++Fout != Fout_end );
+            f += fstride * in_stride;
+        }
     }else{
-        do{
-            // recursive call:
-            // DFT of size m*p performed by doing
-            // p instances of smaller DFTs of size m,
-            // each one takes a decimated version of the input
-            kf_work( Fout , f, fstride*p, in_stride, factors,st);
-            f += fstride*in_stride;
-        }while( (Fout += m) != Fout_end );
+        for(; Fout != Fout_end; Fout += m) {
+            kf_work(Fout, f, fstride * p, in_stride, factors, st);
+            f += fstride * in_stride;
+        }
     }
-    //__android_log_print(ANDROID_LOG_INFO,"----","4");
-    Fout=Fout_beg;
-
+    Fout = Fout_beg;
     // recombine the p smaller DFTs
     switch (p) {
         case 2: kf_bfly2(Fout,fstride,st,m); break;
@@ -298,7 +285,6 @@ void kf_work(
         case 5: kf_bfly5(Fout,fstride,st,m); break;
         default: kf_bfly_generic(Fout,fstride,st,m,p); break;
     }
-    //__android_log_print(ANDROID_LOG_INFO,"----","5");
 }
 
 /*  facbuf is populated by p1,m1,p2,m2, ...
@@ -367,42 +353,34 @@ kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem 
     return st;
 }
 
-
-
-
-void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin, kiss_fft_cpx *fout,int in_stride)
 {
     if (fin == fout) {
-    	//__android_log_print(ANDROID_LOG_INFO,"----","stride");
-        CHECKBUF(tmpbuf,ntmpbuf,st->nfft);
-        //__android_log_print(ANDROID_LOG_INFO,"----","stride1");
-        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
-        //__android_log_print(ANDROID_LOG_INFO,"----","stride2");
-        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        if(fout == NULL) {
+            __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","fout buffer is NULL.");
+            return;
+        }
 
-    }else{
-    	//__android_log_print(ANDROID_LOG_INFO,"----","stride!!!!!");
-        kf_work( fout, fin, 1,in_stride, st->factors,st );
+        int tmpBufMemorySize = sizeof(kiss_fft_cpx) * st->nfft;
+        kiss_fft_cpx *tmpbuf = (kiss_fft_cpx*) KISS_FFT_MALLOC(tmpBufMemorySize);
+        if(tmpbuf == NULL) {
+            __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","Memory allocation failed.");
+            return;
+        }
+
+        __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","tmpbuf call on kfwork at stride");
+        kf_work(tmpbuf, fin,1, in_stride, st->factors,st);
+        memcpy(fout, tmpbuf, tmpBufMemorySize);
+        free(tmpbuf);
+    } else {
+        __android_log_print(ANDROID_LOG_INFO,"KISS_FFT_STRIDE","kfwork call at stride");
+        kf_work( fout, fin, 1, in_stride, st->factors,st );
     }
 }
 
 void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
 {
     kiss_fft_stride(cfg,fin,fout,1);
-}
-
-
-/* not really necessary to call, but if someone is doing in-place ffts, they may want to free the
-   buffers from CHECKBUF
- */
-void kiss_fft_cleanup(void)
-{
-    free(scratchbuf);
-    scratchbuf = NULL;
-    nscratchbuf=0;
-    free(tmpbuf);
-    tmpbuf=NULL;
-    ntmpbuf=0;
 }
 
 int kiss_fft_next_fast_size(int n)

--- a/euphony/src/main/cpp/arms/kiss_fft.h
+++ b/euphony/src/main/cpp/arms/kiss_fft.h
@@ -102,13 +102,6 @@ void kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout
 #define kiss_fft_free free
 
 /*
- Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up
- your compiler output to call this before you exit.
-*/
-void kiss_fft_cleanup(void);
-
-
-/*
  * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
  */
 int kiss_fft_next_fast_size(int n);


### PR DESCRIPTION
- OpenMP를 통해 멀티 스레드 활성화로 FFT 처리속도를 향상시켰습니다.
- 간혹 뜨는 `signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr` 이슈를 아래와 같은 while -> for 문 변경을 통해 코드 가독성을 높이고 문제를 해결했습니다.
- `signal 11 (SIGSEGV), code 1 (SEGV_MAPPER) 이슈가 간혹 뜨는데 FFT 코드 분석을 통해 원인을 찾아야할 것 같습니다.
- 그외 Pointer의 NULL 체크 추가로 코드 안정성을 개선하였습니다.